### PR TITLE
Fix highest severity

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-spectral lint ./openapi/openapi.json --ruleset ./spectral.config.yml --f pretty
+npm run spectral -- lint ./openapi/openapi.json --ruleset ./spectral.config.yml --f pretty

--- a/README.md
+++ b/README.md
@@ -36,11 +36,6 @@ Build the Docker-Compose based local dev environment
 $ docker-compose build --no-cache
 ```
 
-Install the spectral-cli since it's needed in the pre-commit hook
-```bash
-$ npm install -g @stoplight/spectral-cli
-```
-
 ## Running the API in "debug" mode
 
 Per default the API runs in "debug" mode during local development.

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@nestjs/cli": "^8.0.0",
         "@nestjs/schematics": "^8.0.0",
         "@nestjs/testing": "^8.0.0",
+        "@stoplight/spectral-cli": "^6.2.1",
         "@types/bcrypt": "^5.0.0",
         "@types/express": "^4.17.13",
         "@types/jest": "^27.0.1",
@@ -1805,6 +1806,56 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-20.0.0.tgz",
+      "integrity": "sha512-5K0g5W2Ol8hAcTHqcTBHiA7M58tfmYi1o9KxeJuuRNpGaTa5iLjcyemBitCBcKXaHamOBBEH2dGom6v6Unmqjg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.38.3"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -1923,6 +1974,123 @@
         "node": ">=8"
       }
     },
+    "node_modules/@stoplight/spectral-cli": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.2.1.tgz",
+      "integrity": "sha512-Omi/vFk8u+UyM36HbFIuH33oPpOUhDF26xD1N0HoefJstMDUot+L0xVGJWslbVYubuJ7U+JLVLUFLKFU39NfcQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/plugin-commonjs": "^20.0.0",
+        "@stoplight/json": "3.17.0",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-core": "^1.5.1",
+        "@stoplight/spectral-parsers": "^1.0.1",
+        "@stoplight/spectral-ref-resolver": "1.0.1",
+        "@stoplight/spectral-ruleset-bundler": "^1.0.0",
+        "@stoplight/spectral-ruleset-migrator": "^1.5.0",
+        "@stoplight/spectral-rulesets": ">=1",
+        "@stoplight/spectral-runtime": "^1.1.0",
+        "@stoplight/types": "12.3.0",
+        "chalk": "4.1.2",
+        "cliui": "7.0.4",
+        "eol": "0.9.1",
+        "fast-glob": "3.2.7",
+        "lodash": "~4.17.21",
+        "pony-cause": "^1.0.0",
+        "proxy-agent": "5.0.0",
+        "strip-ansi": "6.0",
+        "text-table": "0.2",
+        "tslib": "^2.3.0",
+        "yargs": "17.3.1"
+      },
+      "bin": {
+        "spectral": "dist/index.js"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@stoplight/spectral-cli/node_modules/@stoplight/json": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.17.0.tgz",
+      "integrity": "sha512-WW0z2bb0D4t8FTl+zNTCu46J8lEOsrUhBPgwEYQ3Ri2Y0MiRE4U1/9ZV8Ki+pIJznZgY9i42bbFwOBxyZn5/6w==",
+      "dev": true,
+      "dependencies": {
+        "@stoplight/ordered-object-literal": "^1.0.2",
+        "@stoplight/types": "^12.3.0",
+        "jsonc-parser": "~2.2.1",
+        "lodash": "^4.17.21",
+        "safe-stable-stringify": "^1.1"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/@stoplight/spectral-cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@stoplight/spectral-cli/node_modules/fast-glob": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@stoplight/spectral-cli/node_modules/jsonc-parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
+      "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
+      "dev": true
+    },
+    "node_modules/@stoplight/spectral-cli/node_modules/yargs": {
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+      "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@stoplight/spectral-cli/node_modules/yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@stoplight/spectral-core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.10.0.tgz",
@@ -2036,6 +2204,47 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@stoplight/spectral-ruleset-bundler": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-bundler/-/spectral-ruleset-bundler-1.1.1.tgz",
+      "integrity": "sha512-cDcKzKo77u33chvPRUlkepA4d6Ah5ARPKUnl68gzWQ1Kd1q9ycA6sXaRdZTSn8vKlMnT9ZkEx5wt0A3BtdvUXw==",
+      "dev": true,
+      "dependencies": {
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-core": ">=1",
+        "@stoplight/spectral-formats": ">=1",
+        "@stoplight/spectral-functions": ">=1",
+        "@stoplight/spectral-parsers": ">=1",
+        "@stoplight/spectral-ref-resolver": ">=1",
+        "@stoplight/spectral-ruleset-migrator": "^1.5.2",
+        "@stoplight/spectral-rulesets": ">=1",
+        "@stoplight/spectral-runtime": "^1.1.0",
+        "@stoplight/types": "^12.3.0",
+        "@types/node": "*",
+        "pony-cause": "1.1.1",
+        "rollup": "~2.60.2",
+        "tslib": "^2.3.1",
+        "validate-npm-package-name": "3.0.0"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@stoplight/spectral-ruleset-bundler/node_modules/rollup": {
+      "version": "2.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.60.2.tgz",
+      "integrity": "sha512-1Bgjpq61sPjgoZzuiDSGvbI1tD91giZABgjCQBKM5aYLnzjq52GoDuWVwT/cm/MCxCMPU8gqQvkj8doQ5C8Oqw==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/@stoplight/spectral-ruleset-migrator": {
@@ -3686,6 +3895,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "node_modules/component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -3935,6 +4150,15 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -4000,6 +4224,116 @@
       "dev": true,
       "dependencies": {
         "clone": "^1.0.2"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-3.0.2.tgz",
+      "integrity": "sha512-c0mef3SNQo56t6urUU6tdQAs+ThoD0o9B9MJ8HEt7NQcGEILCRFqQb7ZbP9JAv+QF1Ky5plydhMR/IrqWDm+TQ==",
+      "dev": true,
+      "dependencies": {
+        "ast-types": "^0.13.2",
+        "escodegen": "^1.8.1",
+        "esprima": "^4.0.0",
+        "vm2": "^3.9.8"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/degenerator/node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/degenerator/node_modules/escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/degenerator/node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/degenerator/node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/degenerator/node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/degenerator/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/degenerator/node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -4227,6 +4561,12 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/eol": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
+      "integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==",
+      "dev": true
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -4649,6 +4989,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4950,6 +5296,15 @@
       },
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
+      "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fill-range": {
@@ -5260,6 +5615,19 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/ftp": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
+      "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "1.1.x",
+        "xregexp": "2.0.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5323,6 +5691,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
+      "integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "data-uri-to-buffer": "3",
+        "debug": "4",
+        "file-uri-to-path": "2",
+        "fs-extra": "^8.1.0",
+        "ftp": "^0.3.10"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/get-uri/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/get-uri/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/get-uri/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/glob": {
@@ -5702,6 +6119,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -5802,6 +6225,15 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -7369,6 +7801,15 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/nimma": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.1.7.tgz",
@@ -7663,6 +8104,40 @@
         "node": ">=6"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4",
+        "get-uri": "3",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "5",
+        "pac-resolver": "^5.0.0",
+        "raw-body": "^2.2.0",
+        "socks-proxy-agent": "5"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-5.0.0.tgz",
+      "integrity": "sha512-H+/A6KitiHNNW+bxBKREk2MCGSxljfqRX76NjummWEYIat7ldVXRU3dhRIE3iXZ0nvGBk6smv3nntxKkzRL8NA==",
+      "dev": true,
+      "dependencies": {
+        "degenerator": "^3.0.1",
+        "ip": "^1.1.5",
+        "netmask": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7801,6 +8276,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/pony-cause": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pony-cause/-/pony-cause-1.1.1.tgz",
+      "integrity": "sha512-PxkIc/2ZpLiEzQXu5YRDOUgBlfGYBY8156HY5ZcRAwwonMk5W/MrJP2LLkG/hF7GEQzaHo2aS7ho6ZLCOvf+6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7898,6 +8382,46 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-gkH7BkvLVkSfX9Dk27W6TyNOWWZWRilRfk1XxGNWOYJ2TuedAv1yFpCaU9QSBmBe716XOTNpYNOzhysyw8xn7g==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^6.0.0",
+        "debug": "4",
+        "http-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "lru-cache": "^5.1.1",
+        "pac-proxy-agent": "^5.0.0",
+        "proxy-from-env": "^1.0.0",
+        "socks-proxy-agent": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -8159,6 +8683,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.68.0.tgz",
+      "integrity": "sha512-XrMKOYK7oQcTio4wyTz466mucnd8LzkiZLozZ4Rz0zQD+HeX4nUK4B8GrTX/2EvN2/vBF/i2WnaXboPxo0JylA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-async": {
@@ -8469,6 +9009,44 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+      "dev": true,
+      "dependencies": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "4",
+        "socks": "^2.3.3"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/source-map": {
@@ -9474,6 +10052,43 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vm2": {
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.8.tgz",
+      "integrity": "sha512-/1PYg/BwdKzMPo8maOZ0heT7DLI0DAFTm7YQaz/Lim9oIaFZsJs3EdtalvXuBfZwczNwsYhju75NW4d6E+4q+w==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
+      },
+      "bin": {
+        "vm2": "bin/vm2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/vm2/node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/vm2/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -9816,6 +10431,15 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "node_modules/xregexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -11151,6 +11775,46 @@
         }
       }
     },
+    "@rollup/plugin-commonjs": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-20.0.0.tgz",
+      "integrity": "sha512-5K0g5W2Ol8hAcTHqcTBHiA7M58tfmYi1o9KxeJuuRNpGaTa5iLjcyemBitCBcKXaHamOBBEH2dGom6v6Unmqjg==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.1",
+        "glob": "^7.1.6",
+        "is-reference": "^1.2.1",
+        "magic-string": "^0.25.7",
+        "resolve": "^1.17.0"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "@types/estree": {
+          "version": "0.0.39",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+          "dev": true
+        },
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -11249,6 +11913,101 @@
       "resolved": "https://registry.npmjs.org/@stoplight/path/-/path-1.3.2.tgz",
       "integrity": "sha512-lyIc6JUlUA8Ve5ELywPC8I2Sdnh1zc1zmbYgVarhXIp9YeAB0ReeqmGEOWNtlHkbP2DAA1AL65Wfn2ncjK/jtQ=="
     },
+    "@stoplight/spectral-cli": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.2.1.tgz",
+      "integrity": "sha512-Omi/vFk8u+UyM36HbFIuH33oPpOUhDF26xD1N0HoefJstMDUot+L0xVGJWslbVYubuJ7U+JLVLUFLKFU39NfcQ==",
+      "dev": true,
+      "requires": {
+        "@rollup/plugin-commonjs": "^20.0.0",
+        "@stoplight/json": "3.17.0",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-core": "^1.5.1",
+        "@stoplight/spectral-parsers": "^1.0.1",
+        "@stoplight/spectral-ref-resolver": "1.0.1",
+        "@stoplight/spectral-ruleset-bundler": "^1.0.0",
+        "@stoplight/spectral-ruleset-migrator": "^1.5.0",
+        "@stoplight/spectral-rulesets": ">=1",
+        "@stoplight/spectral-runtime": "^1.1.0",
+        "@stoplight/types": "12.3.0",
+        "chalk": "4.1.2",
+        "cliui": "7.0.4",
+        "eol": "0.9.1",
+        "fast-glob": "3.2.7",
+        "lodash": "~4.17.21",
+        "pony-cause": "^1.0.0",
+        "proxy-agent": "5.0.0",
+        "strip-ansi": "6.0",
+        "text-table": "0.2",
+        "tslib": "^2.3.0",
+        "yargs": "17.3.1"
+      },
+      "dependencies": {
+        "@stoplight/json": {
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/@stoplight/json/-/json-3.17.0.tgz",
+          "integrity": "sha512-WW0z2bb0D4t8FTl+zNTCu46J8lEOsrUhBPgwEYQ3Ri2Y0MiRE4U1/9ZV8Ki+pIJznZgY9i42bbFwOBxyZn5/6w==",
+          "dev": true,
+          "requires": {
+            "@stoplight/ordered-object-literal": "^1.0.2",
+            "@stoplight/types": "^12.3.0",
+            "jsonc-parser": "~2.2.1",
+            "lodash": "^4.17.21",
+            "safe-stable-stringify": "^1.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "fast-glob": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+          "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
+        "jsonc-parser": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
+          "integrity": "sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.0.tgz",
+          "integrity": "sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==",
+          "dev": true
+        }
+      }
+    },
     "@stoplight/spectral-core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.10.0.tgz",
@@ -11346,6 +12105,40 @@
         "@stoplight/spectral-runtime": "^1.0.0",
         "dependency-graph": "0.11.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "@stoplight/spectral-ruleset-bundler": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-bundler/-/spectral-ruleset-bundler-1.1.1.tgz",
+      "integrity": "sha512-cDcKzKo77u33chvPRUlkepA4d6Ah5ARPKUnl68gzWQ1Kd1q9ycA6sXaRdZTSn8vKlMnT9ZkEx5wt0A3BtdvUXw==",
+      "dev": true,
+      "requires": {
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-core": ">=1",
+        "@stoplight/spectral-formats": ">=1",
+        "@stoplight/spectral-functions": ">=1",
+        "@stoplight/spectral-parsers": ">=1",
+        "@stoplight/spectral-ref-resolver": ">=1",
+        "@stoplight/spectral-ruleset-migrator": "^1.5.2",
+        "@stoplight/spectral-rulesets": ">=1",
+        "@stoplight/spectral-runtime": "^1.1.0",
+        "@stoplight/types": "^12.3.0",
+        "@types/node": "*",
+        "pony-cause": "1.1.1",
+        "rollup": "~2.60.2",
+        "tslib": "^2.3.1",
+        "validate-npm-package-name": "3.0.0"
+      },
+      "dependencies": {
+        "rollup": {
+          "version": "2.60.2",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.60.2.tgz",
+          "integrity": "sha512-1Bgjpq61sPjgoZzuiDSGvbI1tD91giZABgjCQBKM5aYLnzjq52GoDuWVwT/cm/MCxCMPU8gqQvkj8doQ5C8Oqw==",
+          "dev": true,
+          "requires": {
+            "fsevents": "~2.3.2"
+          }
+        }
       }
     },
     "@stoplight/spectral-ruleset-migrator": {
@@ -12654,6 +13447,12 @@
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -12864,6 +13663,12 @@
         }
       }
     },
+    "data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+      "dev": true
+    },
     "data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -12915,6 +13720,88 @@
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
+      }
+    },
+    "degenerator": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-3.0.2.tgz",
+      "integrity": "sha512-c0mef3SNQo56t6urUU6tdQAs+ThoD0o9B9MJ8HEt7NQcGEILCRFqQb7ZbP9JAv+QF1Ky5plydhMR/IrqWDm+TQ==",
+      "dev": true,
+      "requires": {
+        "ast-types": "^0.13.2",
+        "escodegen": "^1.8.1",
+        "esprima": "^4.0.0",
+        "vm2": "^3.9.8"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+          "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.0.1"
+          }
+        },
+        "escodegen": {
+          "version": "1.14.3",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+          "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+          "dev": true,
+          "requires": {
+            "esprima": "^4.0.1",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "optionator": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+          "dev": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        }
       }
     },
     "delayed-stream": {
@@ -13089,6 +13976,12 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "eol": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
+      "integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==",
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -13396,6 +14289,12 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -13634,6 +14533,12 @@
         "schema-utils": "^3.0.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
+      "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==",
+      "dev": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -13854,6 +14759,16 @@
       "dev": true,
       "optional": true
     },
+    "ftp": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/ftp/-/ftp-0.3.10.tgz",
+      "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.1.x",
+        "xregexp": "2.0.0"
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -13900,6 +14815,48 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true
+    },
+    "get-uri": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-3.0.2.tgz",
+      "integrity": "sha512-+5s0SJbGoyiJTZZ2JTpFPLMPSch72KEqGOTvQsBqg0RBWvwhWUSYZFAtz3TPW0GXJuLBJPts1E241iHg+VRfhg==",
+      "dev": true,
+      "requires": {
+        "@tootallnate/once": "1",
+        "data-uri-to-buffer": "3",
+        "debug": "4",
+        "file-uri-to-path": "2",
+        "fs-extra": "^8.1.0",
+        "ftp": "^0.3.10"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        }
+      }
     },
     "glob": {
       "version": "7.2.0",
@@ -14163,6 +15120,12 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -14236,6 +15199,15 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
+    },
+    "is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
     },
     "is-stream": {
       "version": "2.0.1",
@@ -15445,6 +16417,12 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true
+    },
     "nimma": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/nimma/-/nimma-0.1.7.tgz",
@@ -15664,6 +16642,34 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "pac-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ==",
+      "dev": true,
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4",
+        "get-uri": "3",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "5",
+        "pac-resolver": "^5.0.0",
+        "raw-body": "^2.2.0",
+        "socks-proxy-agent": "5"
+      }
+    },
+    "pac-resolver": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-5.0.0.tgz",
+      "integrity": "sha512-H+/A6KitiHNNW+bxBKREk2MCGSxljfqRX76NjummWEYIat7ldVXRU3dhRIE3iXZ0nvGBk6smv3nntxKkzRL8NA==",
+      "dev": true,
+      "requires": {
+        "degenerator": "^3.0.1",
+        "ip": "^1.1.5",
+        "netmask": "^2.0.1"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -15763,6 +16769,12 @@
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "dev": true
     },
+    "pony-cause": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pony-cause/-/pony-cause-1.1.1.tgz",
+      "integrity": "sha512-PxkIc/2ZpLiEzQXu5YRDOUgBlfGYBY8156HY5ZcRAwwonMk5W/MrJP2LLkG/hF7GEQzaHo2aS7ho6ZLCOvf+6g==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -15832,6 +16844,45 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-gkH7BkvLVkSfX9Dk27W6TyNOWWZWRilRfk1XxGNWOYJ2TuedAv1yFpCaU9QSBmBe716XOTNpYNOzhysyw8xn7g==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^6.0.0",
+        "debug": "4",
+        "http-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "lru-cache": "^5.1.1",
+        "pac-proxy-agent": "^5.0.0",
+        "proxy-from-env": "^1.0.0",
+        "socks-proxy-agent": "^5.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
+      }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "psl": {
       "version": "1.8.0",
@@ -16014,6 +17065,16 @@
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.68.0.tgz",
+      "integrity": "sha512-XrMKOYK7oQcTio4wyTz466mucnd8LzkiZLozZ4Rz0zQD+HeX4nUK4B8GrTX/2EvN2/vBF/i2WnaXboPxo0JylA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "fsevents": "~2.3.2"
       }
     },
     "run-async": {
@@ -16255,6 +17316,33 @@
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
+      }
+    },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true
+    },
+    "socks": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+      "dev": true,
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.2.0"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^6.0.2",
+        "debug": "4",
+        "socks": "^2.3.3"
       }
     },
     "source-map": {
@@ -16963,6 +18051,30 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
+    "vm2": {
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.8.tgz",
+      "integrity": "sha512-/1PYg/BwdKzMPo8maOZ0heT7DLI0DAFTm7YQaz/Lim9oIaFZsJs3EdtalvXuBfZwczNwsYhju75NW4d6E+4q+w==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+          "dev": true
+        },
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        }
+      }
+    },
     "w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -17214,6 +18326,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
+    "xregexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz",
+      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:cov": "jest --config ./jest.json --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "copy-assets": "cp -rv src/spectral.yml dist/spectral.yml"
+    "copy-assets": "cp -rv src/spectral.yml dist/spectral.yml",
+    "spectral": "spectral"
   },
   "dependencies": {
     "@nestjs/common": "^8.2.4",
@@ -51,6 +52,7 @@
     "@nestjs/cli": "^8.0.0",
     "@nestjs/schematics": "^8.0.0",
     "@nestjs/testing": "^8.0.0",
+    "@stoplight/spectral-cli": "^6.2.1",
     "@types/bcrypt": "^5.0.0",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.0.1",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest --config ./jest.json && npm run test:e2e",
     "pretest": "node download-rules.js",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
+    "test:watch": "jest --config ./jest.json --watch",
+    "test:cov": "jest --config ./jest.json --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "copy-assets": "cp -rv src/spectral.yml dist/spectral.yml"

--- a/src/lintings/lintings.service.spec.ts
+++ b/src/lintings/lintings.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test } from '@nestjs/testing';
 import { LintingsService } from './lintings.service';
 import { CreateLintingDto } from './create-linting.dto';
+import { ISpectralDiagnostic } from '@stoplight/spectral-core';
 
 describe('LintingsService', () => {
   let lintingsService: LintingsService;
@@ -18,9 +19,11 @@ describe('LintingsService', () => {
   it('should be defined', () => {
     expect(lintingsService).toBeDefined();
   });
+
   it('should have a public "validateApiSpec" method defined', () => {
     expect(lintingsService.validateApiSpec).toBeDefined();
   });
+
   it('should successfully validate a given api spec', async () => {
     const createLintingDto: CreateLintingDto = {
       apiType: 'product_api',
@@ -33,4 +36,26 @@ describe('LintingsService', () => {
       (await lintingsService.validateApiSpec(createLintingDto)).isValidSpec,
     ).toBe(true);
   });
+
+  it.each<[number[], 'Error' | 'Warn' | 'Info' | 'Hint' | undefined]>([
+    [[], undefined],
+    [[2, 3, 0, 1, 3], 'Error'],
+    [[2, 3, 5, 1, 3], 'Warn'],
+    [[2, 3, 5, 3, 2], 'Info'],
+    [[5, 3, 42, 333], 'Hint'],
+  ])(
+    'should find the highest severity level',
+    (severities, expectedSeverity) => {
+      const results: ISpectralDiagnostic[] = severities.map((severity) => ({
+        code: '',
+        message: '',
+        path: [],
+        range: null,
+        severity,
+        relatedInformation: null,
+      }));
+      const highestSeverity = lintingsService.getHighestSeverityLevel(results);
+      expect(highestSeverity).toBe(expectedSeverity);
+    },
+  );
 });

--- a/src/lintings/lintings.service.ts
+++ b/src/lintings/lintings.service.ts
@@ -55,7 +55,7 @@ export class LintingsService {
         description: 'Given API Spec DOES NOT comply with company API rules.',
         linkApiRules:
           'https://onedirection.schwarz/architecture-best-practices/apis/',
-        highestSeverityLevel: SeverityLevel[0],
+        highestSeverityLevel: this.getHighestSeverityLevel(lintingResult),
         lintingResults: lintingResult,
       };
       return failedResponse;
@@ -65,9 +65,21 @@ export class LintingsService {
       description: 'Given API Spec DOES comply with company API rules.',
       linkApiRules:
         'https://onedirection.schwarz/architecture-best-practices/apis/',
+      highestSeverityLevel: this.getHighestSeverityLevel(lintingResult),
       lintingResults: lintingResult,
     };
     return response;
+  }
+
+  getHighestSeverityLevel(results: ISpectralDiagnostic[]) {
+    const severities = results.reduce((acc, curr) => {
+      acc.push(curr.severity);
+      return acc;
+    }, [] as number[]);
+
+    if (severities.length === 0) return undefined;
+
+    return SeverityLevel[Math.min(...severities)];
   }
 
   private async getLintingResult(swaggerFile): Promise<ISpectralDiagnostic[]> {

--- a/src/spectral-api.js
+++ b/src/spectral-api.js
@@ -1,4 +1,4 @@
-const {length: length$0, pattern, truthy} = require("@stoplight/spectral-functions");
+const {length: length$0, pattern, truthy, xor} = require("@stoplight/spectral-functions");
 const {oas} = require("@stoplight/spectral-rulesets");
 module.exports = {
   "extends": [{
@@ -6,7 +6,7 @@ module.exports = {
     "rules": {
       "operation-tag-defined": "off",
       "path-must-match-api-standards": {
-        "description": "API Path must match company api uri standards",
+        "description": "API Path must match company API uri standards",
         "message": "{{description}}; {{property}} incorrect. Example: /digital-twin/api/v1/products",
         "severity": "error",
         "resolved": false,
@@ -19,7 +19,7 @@ module.exports = {
         }
       },
       "servers-must-match-api-standards": {
-        "description": "Servers must match company api standards",
+        "description": "Schema and host in URL must match company API standards",
         "message": "{{description}}; {{property}}:{{value}} incorrect. Example: https://live.api.schwarz/digital-twin/api/v1/products",
         "severity": "error",
         "resolved": false,
@@ -27,9 +27,66 @@ module.exports = {
         "then": {
           "function": pattern,
           "functionOptions": {
-            "match": "^((http[s]?)://)([a-z]+)([.+])api.schwarz"
+            "match": "^((http[s]?):\\/\\/)([a-z]+)([.+])api.schwarz"
           }
         }
+      },
+      "info-description": {
+        "description": "Every API must have a global description",
+        "message": "OpenAPI object info `description` must be present and at least 100 chars long.",
+        "severity": "error",
+        "given": "$.info",
+        "then": [{
+          "field": "description",
+          "function": truthy
+        }, {
+          "field": "description",
+          "function": length$0,
+          "functionOptions": {
+            "min": 100
+          }
+        }]
+      },
+      "contact-information": {
+        "description": "Every API must have a contact containing name, email and a url",
+        "message": "{{description}}; property {{property}} is missing",
+        "severity": "error",
+        "given": "$.info.contact",
+        "then": [{
+          "field": "name",
+          "function": truthy
+        }, {
+          "field": "email",
+          "function": truthy
+        }, {
+          "field": "url",
+          "function": truthy
+        }]
+      },
+      "path-dto-reference": {
+        "description": "DTOs should be used to specify the schema(data types) of a request / response",
+        "message": "{{description}}; property {{property}} is missing",
+        "severity": "error",
+        "given": "$.components.schemas",
+        "then": [{
+          "function": length$0,
+          "functionOptions": {
+            "min": 1
+          }
+        }]
+      },
+      "must-have-path": {
+        "description": "Every API must have at least one path",
+        "message": "{{description}}; property `paths` is empty",
+        "severity": "error",
+        "given": "$",
+        "then": [{
+          "field": "paths",
+          "function": length$0,
+          "functionOptions": {
+            "min": 1
+          }
+        }]
       },
       "common-responses-unauthorized": {
         "description": "Responses should contain common response - 401 (unauthorized)",
@@ -64,18 +121,18 @@ module.exports = {
         }]
       },
       "no-http-verbs-in-resources": {
-        "description": "The HTTP URL should not be used to define different actions on a resource",
+        "description": "The HTTP Verbs should not be used in the route path to define different actions on a resource",
         "message": "{{description}}; {{property}} Instead use HTTP verbs to define actions on a resource. Example: PUT - /digital-twin/api/v1/products/42",
         "severity": "error",
         "given": "$.paths[?(!@property.match(/well-known/ig))]~",
         "then": {
           "function": pattern,
           "functionOptions": {
-            "notMatch": "/(get|post|put|patch|delete)(/|$)"
+            "notMatch": "\\/(get|post|put|patch|delete)(\\/|$)"
           }
         }
       },
-      "description-is-mandatory": {
+      "path-description-is-mandatory": {
         "description": "Every route of an API should have a description",
         "message": "{{description}}; property: {{property}} is missing",
         "severity": "error",
@@ -85,54 +142,51 @@ module.exports = {
           "function": truthy
         }]
       },
-      "info-description": {
-        "description": "Every API must have a global description",
-        "message": "OpenAPI object info `description` must be present and at least 100 chars long.",
+      "must-have-response-body": {
+        "description": "Every route returning a http status code of 200 or 201 must have a response body defined",
+        "message": "{{description}}; property {{property}} is missing at path: {{path}}",
         "severity": "error",
-        "given": "$.info",
+        "given": "$.paths[?(!@property.match(/well-known/ig))]..responses[200,201]",
         "then": [{
-          "field": "description",
+          "field": "content",
           "function": truthy
         }, {
           "field": "description",
-          "function": length$0,
+          "function": truthy
+        }]
+      },
+      "must-have-content-type": {
+        "description": "Every response must specify its content type",
+        "message": "{{description}}; property {{property}} is missing or not a valid content-type",
+        "severity": "error",
+        "given": "$.paths[?(!@property.match(/well-known/ig))]..content",
+        "then": [{
+          "field": "@key",
+          "function": pattern,
           "functionOptions": {
-            "min": 100
+            "match": "/"
           }
         }]
       },
-      "contact-information": {
-        "description": "Every API must have a contact containing name, email and a url",
-        "message": "{{description}}; property {{property}} is missing",
+      "must-define-example-schema": {
+        "description": "Every DTO must define at least one example",
+        "message": "{{description}}; DTO is lacking an example {{path}}",
         "severity": "error",
-        "given": "$.info.contact",
+        "given": "$.paths[?(!@property.match(/well-known/ig))]..content.*",
         "then": [{
-          "field": "name",
-          "function": truthy
-        }, {
-          "field": "email",
-          "function": truthy
-        }, {
-          "field": "url",
-          "function": truthy
+          "function": xor,
+          "functionOptions": {
+            "properties": ["example", "examples"]
+          }
         }]
       },
-      "path-description": {
-        "description": "Each path of an API must have a description",
-        "message": "{{description}}; property `description` is missing for path {{path}}",
+      "path-must-specify-tags": {
+        "description": "Every route must specify at least one tag it belongs to",
+        "message": "{{description}}; property tags is missing at: {{path}}",
         "severity": "error",
-        "given": "$.paths[?(!@property.match(/well-known/ig))]",
+        "given": "$.paths[?(!@property.match(/well-known/ig))].*",
         "then": [{
-          "field": "description",
-          "function": truthy
-        }]
-      },
-      "path-dto-reference": {
-        "description": "DTOs should be used to specify the schema of a request / response",
-        "message": "{{description}}; property {{property}} is missing",
-        "severity": "error",
-        "given": "$.components.schemas",
-        "then": [{
+          "field": "tags",
           "function": length$0,
           "functionOptions": {
             "min": 1
@@ -145,13 +199,17 @@ module.exports = {
     "operation-tag-defined": "off",
     "path-must-match-api-standards": "off",
     "servers-must-match-api-standards": "off",
-    "common-responses-unauthorized": "warn",
-    "http-verbs-should-be-used": "warn",
+    "common-responses-unauthorized": "hint",
+    "http-verbs-should-be-used": "info",
     "no-http-verbs-in-resources": "warn",
-    "description-is-mandatory": "warn",
+    "path-description-is-mandatory": "warn",
     "info-description": "warn",
     "contact-information": "warn",
-    "path-description": "warn",
-    "path-dto-reference": "warn"
+    "path-dto-reference": "warn",
+    "must-have-path": "warn",
+    "must-have-response-body": "warn",
+    "must-have-content-type": "warn",
+    "must-define-example-schema": "warn",
+    "path-must-specify-tags": "warn"
   }
 };

--- a/src/spectral-bff.js
+++ b/src/spectral-bff.js
@@ -1,4 +1,4 @@
-const {length: length$0, pattern, truthy} = require("@stoplight/spectral-functions");
+const {length: length$0, pattern, truthy, xor} = require("@stoplight/spectral-functions");
 const {oas} = require("@stoplight/spectral-rulesets");
 module.exports = {
   "extends": [{
@@ -6,7 +6,7 @@ module.exports = {
     "rules": {
       "operation-tag-defined": "off",
       "path-must-match-api-standards": {
-        "description": "API Path must match company api uri standards",
+        "description": "API Path must match company API uri standards",
         "message": "{{description}}; {{property}} incorrect. Example: /digital-twin/api/v1/products",
         "severity": "error",
         "resolved": false,
@@ -19,7 +19,7 @@ module.exports = {
         }
       },
       "servers-must-match-api-standards": {
-        "description": "Servers must match company api standards",
+        "description": "Schema and host in URL must match company API standards",
         "message": "{{description}}; {{property}}:{{value}} incorrect. Example: https://live.api.schwarz/digital-twin/api/v1/products",
         "severity": "error",
         "resolved": false,
@@ -27,9 +27,66 @@ module.exports = {
         "then": {
           "function": pattern,
           "functionOptions": {
-            "match": "^((http[s]?)://)([a-z]+)([.+])api.schwarz"
+            "match": "^((http[s]?):\\/\\/)([a-z]+)([.+])api.schwarz"
           }
         }
+      },
+      "info-description": {
+        "description": "Every API must have a global description",
+        "message": "OpenAPI object info `description` must be present and at least 100 chars long.",
+        "severity": "error",
+        "given": "$.info",
+        "then": [{
+          "field": "description",
+          "function": truthy
+        }, {
+          "field": "description",
+          "function": length$0,
+          "functionOptions": {
+            "min": 100
+          }
+        }]
+      },
+      "contact-information": {
+        "description": "Every API must have a contact containing name, email and a url",
+        "message": "{{description}}; property {{property}} is missing",
+        "severity": "error",
+        "given": "$.info.contact",
+        "then": [{
+          "field": "name",
+          "function": truthy
+        }, {
+          "field": "email",
+          "function": truthy
+        }, {
+          "field": "url",
+          "function": truthy
+        }]
+      },
+      "path-dto-reference": {
+        "description": "DTOs should be used to specify the schema(data types) of a request / response",
+        "message": "{{description}}; property {{property}} is missing",
+        "severity": "error",
+        "given": "$.components.schemas",
+        "then": [{
+          "function": length$0,
+          "functionOptions": {
+            "min": 1
+          }
+        }]
+      },
+      "must-have-path": {
+        "description": "Every API must have at least one path",
+        "message": "{{description}}; property `paths` is empty",
+        "severity": "error",
+        "given": "$",
+        "then": [{
+          "field": "paths",
+          "function": length$0,
+          "functionOptions": {
+            "min": 1
+          }
+        }]
       },
       "common-responses-unauthorized": {
         "description": "Responses should contain common response - 401 (unauthorized)",
@@ -64,18 +121,18 @@ module.exports = {
         }]
       },
       "no-http-verbs-in-resources": {
-        "description": "The HTTP URL should not be used to define different actions on a resource",
+        "description": "The HTTP Verbs should not be used in the route path to define different actions on a resource",
         "message": "{{description}}; {{property}} Instead use HTTP verbs to define actions on a resource. Example: PUT - /digital-twin/api/v1/products/42",
         "severity": "error",
         "given": "$.paths[?(!@property.match(/well-known/ig))]~",
         "then": {
           "function": pattern,
           "functionOptions": {
-            "notMatch": "/(get|post|put|patch|delete)(/|$)"
+            "notMatch": "\\/(get|post|put|patch|delete)(\\/|$)"
           }
         }
       },
-      "description-is-mandatory": {
+      "path-description-is-mandatory": {
         "description": "Every route of an API should have a description",
         "message": "{{description}}; property: {{property}} is missing",
         "severity": "error",
@@ -85,54 +142,51 @@ module.exports = {
           "function": truthy
         }]
       },
-      "info-description": {
-        "description": "Every API must have a global description",
-        "message": "OpenAPI object info `description` must be present and at least 100 chars long.",
+      "must-have-response-body": {
+        "description": "Every route returning a http status code of 200 or 201 must have a response body defined",
+        "message": "{{description}}; property {{property}} is missing at path: {{path}}",
         "severity": "error",
-        "given": "$.info",
+        "given": "$.paths[?(!@property.match(/well-known/ig))]..responses[200,201]",
         "then": [{
-          "field": "description",
+          "field": "content",
           "function": truthy
         }, {
           "field": "description",
-          "function": length$0,
+          "function": truthy
+        }]
+      },
+      "must-have-content-type": {
+        "description": "Every response must specify its content type",
+        "message": "{{description}}; property {{property}} is missing or not a valid content-type",
+        "severity": "error",
+        "given": "$.paths[?(!@property.match(/well-known/ig))]..content",
+        "then": [{
+          "field": "@key",
+          "function": pattern,
           "functionOptions": {
-            "min": 100
+            "match": "/"
           }
         }]
       },
-      "contact-information": {
-        "description": "Every API must have a contact containing name, email and a url",
-        "message": "{{description}}; property {{property}} is missing",
+      "must-define-example-schema": {
+        "description": "Every DTO must define at least one example",
+        "message": "{{description}}; DTO is lacking an example {{path}}",
         "severity": "error",
-        "given": "$.info.contact",
+        "given": "$.paths[?(!@property.match(/well-known/ig))]..content.*",
         "then": [{
-          "field": "name",
-          "function": truthy
-        }, {
-          "field": "email",
-          "function": truthy
-        }, {
-          "field": "url",
-          "function": truthy
+          "function": xor,
+          "functionOptions": {
+            "properties": ["example", "examples"]
+          }
         }]
       },
-      "path-description": {
-        "description": "Each path of an API must have a description",
-        "message": "{{description}}; property `description` is missing for path {{path}}",
+      "path-must-specify-tags": {
+        "description": "Every route must specify at least one tag it belongs to",
+        "message": "{{description}}; property tags is missing at: {{path}}",
         "severity": "error",
-        "given": "$.paths[?(!@property.match(/well-known/ig))]",
+        "given": "$.paths[?(!@property.match(/well-known/ig))].*",
         "then": [{
-          "field": "description",
-          "function": truthy
-        }]
-      },
-      "path-dto-reference": {
-        "description": "DTOs should be used to specify the schema of a request / response",
-        "message": "{{description}}; property {{property}} is missing",
-        "severity": "error",
-        "given": "$.components.schemas",
-        "then": [{
+          "field": "tags",
           "function": length$0,
           "functionOptions": {
             "min": 1
@@ -145,13 +199,17 @@ module.exports = {
     "operation-tag-defined": "off",
     "path-must-match-api-standards": "off",
     "servers-must-match-api-standards": "off",
-    "common-responses-unauthorized": "info",
+    "common-responses-unauthorized": "hint",
     "http-verbs-should-be-used": "info",
     "no-http-verbs-in-resources": "info",
-    "description-is-mandatory": "info",
+    "path-description-is-mandatory": "info",
     "info-description": "info",
     "contact-information": "info",
-    "path-description": "info",
-    "path-dto-reference": "info"
+    "path-dto-reference": "info",
+    "must-have-path": "info",
+    "must-have-response-body": "info",
+    "must-have-content-type": "info",
+    "must-define-example-schema": "info",
+    "path-must-specify-tags": "info"
   }
 };

--- a/src/spectral-legacy.js
+++ b/src/spectral-legacy.js
@@ -1,4 +1,4 @@
-const {length: length$0, pattern, truthy} = require("@stoplight/spectral-functions");
+const {length: length$0, pattern, truthy, xor} = require("@stoplight/spectral-functions");
 const {oas} = require("@stoplight/spectral-rulesets");
 module.exports = {
   "extends": [{
@@ -6,7 +6,7 @@ module.exports = {
     "rules": {
       "operation-tag-defined": "off",
       "path-must-match-api-standards": {
-        "description": "API Path must match company api uri standards",
+        "description": "API Path must match company API uri standards",
         "message": "{{description}}; {{property}} incorrect. Example: /digital-twin/api/v1/products",
         "severity": "error",
         "resolved": false,
@@ -19,7 +19,7 @@ module.exports = {
         }
       },
       "servers-must-match-api-standards": {
-        "description": "Servers must match company api standards",
+        "description": "Schema and host in URL must match company API standards",
         "message": "{{description}}; {{property}}:{{value}} incorrect. Example: https://live.api.schwarz/digital-twin/api/v1/products",
         "severity": "error",
         "resolved": false,
@@ -27,9 +27,66 @@ module.exports = {
         "then": {
           "function": pattern,
           "functionOptions": {
-            "match": "^((http[s]?)://)([a-z]+)([.+])api.schwarz"
+            "match": "^((http[s]?):\\/\\/)([a-z]+)([.+])api.schwarz"
           }
         }
+      },
+      "info-description": {
+        "description": "Every API must have a global description",
+        "message": "OpenAPI object info `description` must be present and at least 100 chars long.",
+        "severity": "error",
+        "given": "$.info",
+        "then": [{
+          "field": "description",
+          "function": truthy
+        }, {
+          "field": "description",
+          "function": length$0,
+          "functionOptions": {
+            "min": 100
+          }
+        }]
+      },
+      "contact-information": {
+        "description": "Every API must have a contact containing name, email and a url",
+        "message": "{{description}}; property {{property}} is missing",
+        "severity": "error",
+        "given": "$.info.contact",
+        "then": [{
+          "field": "name",
+          "function": truthy
+        }, {
+          "field": "email",
+          "function": truthy
+        }, {
+          "field": "url",
+          "function": truthy
+        }]
+      },
+      "path-dto-reference": {
+        "description": "DTOs should be used to specify the schema(data types) of a request / response",
+        "message": "{{description}}; property {{property}} is missing",
+        "severity": "error",
+        "given": "$.components.schemas",
+        "then": [{
+          "function": length$0,
+          "functionOptions": {
+            "min": 1
+          }
+        }]
+      },
+      "must-have-path": {
+        "description": "Every API must have at least one path",
+        "message": "{{description}}; property `paths` is empty",
+        "severity": "error",
+        "given": "$",
+        "then": [{
+          "field": "paths",
+          "function": length$0,
+          "functionOptions": {
+            "min": 1
+          }
+        }]
       },
       "common-responses-unauthorized": {
         "description": "Responses should contain common response - 401 (unauthorized)",
@@ -64,18 +121,18 @@ module.exports = {
         }]
       },
       "no-http-verbs-in-resources": {
-        "description": "The HTTP URL should not be used to define different actions on a resource",
+        "description": "The HTTP Verbs should not be used in the route path to define different actions on a resource",
         "message": "{{description}}; {{property}} Instead use HTTP verbs to define actions on a resource. Example: PUT - /digital-twin/api/v1/products/42",
         "severity": "error",
         "given": "$.paths[?(!@property.match(/well-known/ig))]~",
         "then": {
           "function": pattern,
           "functionOptions": {
-            "notMatch": "/(get|post|put|patch|delete)(/|$)"
+            "notMatch": "\\/(get|post|put|patch|delete)(\\/|$)"
           }
         }
       },
-      "description-is-mandatory": {
+      "path-description-is-mandatory": {
         "description": "Every route of an API should have a description",
         "message": "{{description}}; property: {{property}} is missing",
         "severity": "error",
@@ -85,54 +142,51 @@ module.exports = {
           "function": truthy
         }]
       },
-      "info-description": {
-        "description": "Every API must have a global description",
-        "message": "OpenAPI object info `description` must be present and at least 100 chars long.",
+      "must-have-response-body": {
+        "description": "Every route returning a http status code of 200 or 201 must have a response body defined",
+        "message": "{{description}}; property {{property}} is missing at path: {{path}}",
         "severity": "error",
-        "given": "$.info",
+        "given": "$.paths[?(!@property.match(/well-known/ig))]..responses[200,201]",
         "then": [{
-          "field": "description",
+          "field": "content",
           "function": truthy
         }, {
           "field": "description",
-          "function": length$0,
+          "function": truthy
+        }]
+      },
+      "must-have-content-type": {
+        "description": "Every response must specify its content type",
+        "message": "{{description}}; property {{property}} is missing or not a valid content-type",
+        "severity": "error",
+        "given": "$.paths[?(!@property.match(/well-known/ig))]..content",
+        "then": [{
+          "field": "@key",
+          "function": pattern,
           "functionOptions": {
-            "min": 100
+            "match": "/"
           }
         }]
       },
-      "contact-information": {
-        "description": "Every API must have a contact containing name, email and a url",
-        "message": "{{description}}; property {{property}} is missing",
+      "must-define-example-schema": {
+        "description": "Every DTO must define at least one example",
+        "message": "{{description}}; DTO is lacking an example {{path}}",
         "severity": "error",
-        "given": "$.info.contact",
+        "given": "$.paths[?(!@property.match(/well-known/ig))]..content.*",
         "then": [{
-          "field": "name",
-          "function": truthy
-        }, {
-          "field": "email",
-          "function": truthy
-        }, {
-          "field": "url",
-          "function": truthy
+          "function": xor,
+          "functionOptions": {
+            "properties": ["example", "examples"]
+          }
         }]
       },
-      "path-description": {
-        "description": "Each path of an API must have a description",
-        "message": "{{description}}; property `description` is missing for path {{path}}",
+      "path-must-specify-tags": {
+        "description": "Every route must specify at least one tag it belongs to",
+        "message": "{{description}}; property tags is missing at: {{path}}",
         "severity": "error",
-        "given": "$.paths[?(!@property.match(/well-known/ig))]",
+        "given": "$.paths[?(!@property.match(/well-known/ig))].*",
         "then": [{
-          "field": "description",
-          "function": truthy
-        }]
-      },
-      "path-dto-reference": {
-        "description": "DTOs should be used to specify the schema of a request / response",
-        "message": "{{description}}; property {{property}} is missing",
-        "severity": "error",
-        "given": "$.components.schemas",
-        "then": [{
+          "field": "tags",
           "function": length$0,
           "functionOptions": {
             "min": 1
@@ -146,12 +200,16 @@ module.exports = {
     "path-must-match-api-standards": "off",
     "servers-must-match-api-standards": "off",
     "common-responses-unauthorized": "hint",
-    "http-verbs-should-be-used": "hint",
-    "no-http-verbs-in-resources": "hint",
-    "description-is-mandatory": "hint",
-    "info-description": "hint",
-    "contact-information": "hint",
-    "path-description": "hint",
-    "path-dto-reference": "hint"
+    "http-verbs-should-be-used": "info",
+    "no-http-verbs-in-resources": "info",
+    "path-description-is-mandatory": "info",
+    "info-description": "info",
+    "contact-information": "info",
+    "path-dto-reference": "info",
+    "must-have-path": "info",
+    "must-have-response-body": "info",
+    "must-have-content-type": "info",
+    "must-define-example-schema": "info",
+    "path-must-specify-tags": "info"
   }
 };

--- a/src/spectral.js
+++ b/src/spectral.js
@@ -1,11 +1,11 @@
-const {length: length$0, pattern, truthy} = require("@stoplight/spectral-functions");
+const {length: length$0, pattern, truthy, xor} = require("@stoplight/spectral-functions");
 const {oas} = require("@stoplight/spectral-rulesets");
 module.exports = {
   "extends": [[oas, "recommended"]],
   "rules": {
     "operation-tag-defined": "off",
     "path-must-match-api-standards": {
-      "description": "API Path must match company api uri standards",
+      "description": "API Path must match company API uri standards",
       "message": "{{description}}; {{property}} incorrect. Example: /digital-twin/api/v1/products",
       "severity": "error",
       "resolved": false,
@@ -18,7 +18,7 @@ module.exports = {
       }
     },
     "servers-must-match-api-standards": {
-      "description": "Servers must match company api standards",
+      "description": "Schema and host in URL must match company API standards",
       "message": "{{description}}; {{property}}:{{value}} incorrect. Example: https://live.api.schwarz/digital-twin/api/v1/products",
       "severity": "error",
       "resolved": false,
@@ -26,9 +26,66 @@ module.exports = {
       "then": {
         "function": pattern,
         "functionOptions": {
-          "match": "^((http[s]?)://)([a-z]+)([.+])api.schwarz"
+          "match": "^((http[s]?):\\/\\/)([a-z]+)([.+])api.schwarz"
         }
       }
+    },
+    "info-description": {
+      "description": "Every API must have a global description",
+      "message": "OpenAPI object info `description` must be present and at least 100 chars long.",
+      "severity": "error",
+      "given": "$.info",
+      "then": [{
+        "field": "description",
+        "function": truthy
+      }, {
+        "field": "description",
+        "function": length$0,
+        "functionOptions": {
+          "min": 100
+        }
+      }]
+    },
+    "contact-information": {
+      "description": "Every API must have a contact containing name, email and a url",
+      "message": "{{description}}; property {{property}} is missing",
+      "severity": "error",
+      "given": "$.info.contact",
+      "then": [{
+        "field": "name",
+        "function": truthy
+      }, {
+        "field": "email",
+        "function": truthy
+      }, {
+        "field": "url",
+        "function": truthy
+      }]
+    },
+    "path-dto-reference": {
+      "description": "DTOs should be used to specify the schema(data types) of a request / response",
+      "message": "{{description}}; property {{property}} is missing",
+      "severity": "error",
+      "given": "$.components.schemas",
+      "then": [{
+        "function": length$0,
+        "functionOptions": {
+          "min": 1
+        }
+      }]
+    },
+    "must-have-path": {
+      "description": "Every API must have at least one path",
+      "message": "{{description}}; property `paths` is empty",
+      "severity": "error",
+      "given": "$",
+      "then": [{
+        "field": "paths",
+        "function": length$0,
+        "functionOptions": {
+          "min": 1
+        }
+      }]
     },
     "common-responses-unauthorized": {
       "description": "Responses should contain common response - 401 (unauthorized)",
@@ -63,18 +120,18 @@ module.exports = {
       }]
     },
     "no-http-verbs-in-resources": {
-      "description": "The HTTP URL should not be used to define different actions on a resource",
+      "description": "The HTTP Verbs should not be used in the route path to define different actions on a resource",
       "message": "{{description}}; {{property}} Instead use HTTP verbs to define actions on a resource. Example: PUT - /digital-twin/api/v1/products/42",
       "severity": "error",
       "given": "$.paths[?(!@property.match(/well-known/ig))]~",
       "then": {
         "function": pattern,
         "functionOptions": {
-          "notMatch": "/(get|post|put|patch|delete)(/|$)"
+          "notMatch": "\\/(get|post|put|patch|delete)(\\/|$)"
         }
       }
     },
-    "description-is-mandatory": {
+    "path-description-is-mandatory": {
       "description": "Every route of an API should have a description",
       "message": "{{description}}; property: {{property}} is missing",
       "severity": "error",
@@ -84,54 +141,51 @@ module.exports = {
         "function": truthy
       }]
     },
-    "info-description": {
-      "description": "Every API must have a global description",
-      "message": "OpenAPI object info `description` must be present and at least 100 chars long.",
+    "must-have-response-body": {
+      "description": "Every route returning a http status code of 200 or 201 must have a response body defined",
+      "message": "{{description}}; property {{property}} is missing at path: {{path}}",
       "severity": "error",
-      "given": "$.info",
+      "given": "$.paths[?(!@property.match(/well-known/ig))]..responses[200,201]",
       "then": [{
-        "field": "description",
+        "field": "content",
         "function": truthy
       }, {
         "field": "description",
-        "function": length$0,
+        "function": truthy
+      }]
+    },
+    "must-have-content-type": {
+      "description": "Every response must specify its content type",
+      "message": "{{description}}; property {{property}} is missing or not a valid content-type",
+      "severity": "error",
+      "given": "$.paths[?(!@property.match(/well-known/ig))]..content",
+      "then": [{
+        "field": "@key",
+        "function": pattern,
         "functionOptions": {
-          "min": 100
+          "match": "/"
         }
       }]
     },
-    "contact-information": {
-      "description": "Every API must have a contact containing name, email and a url",
-      "message": "{{description}}; property {{property}} is missing",
+    "must-define-example-schema": {
+      "description": "Every DTO must define at least one example",
+      "message": "{{description}}; DTO is lacking an example {{path}}",
       "severity": "error",
-      "given": "$.info.contact",
+      "given": "$.paths[?(!@property.match(/well-known/ig))]..content.*",
       "then": [{
-        "field": "name",
-        "function": truthy
-      }, {
-        "field": "email",
-        "function": truthy
-      }, {
-        "field": "url",
-        "function": truthy
+        "function": xor,
+        "functionOptions": {
+          "properties": ["example", "examples"]
+        }
       }]
     },
-    "path-description": {
-      "description": "Each path of an API must have a description",
-      "message": "{{description}}; property `description` is missing for path {{path}}",
+    "path-must-specify-tags": {
+      "description": "Every route must specify at least one tag it belongs to",
+      "message": "{{description}}; property tags is missing at: {{path}}",
       "severity": "error",
-      "given": "$.paths[?(!@property.match(/well-known/ig))]",
+      "given": "$.paths[?(!@property.match(/well-known/ig))].*",
       "then": [{
-        "field": "description",
-        "function": truthy
-      }]
-    },
-    "path-dto-reference": {
-      "description": "DTOs should be used to specify the schema of a request / response",
-      "message": "{{description}}; property {{property}} is missing",
-      "severity": "error",
-      "given": "$.components.schemas",
-      "then": [{
+        "field": "tags",
         "function": length$0,
         "functionOptions": {
           "min": 1

--- a/test/__snapshots__/lintings-e2e-spec.ts.snap
+++ b/test/__snapshots__/lintings-e2e-spec.ts.snap
@@ -3,11 +3,31 @@
 exports[`[Feature] Lintings - /api-linting/api/v1/lintings POST successfully creates a new linting: lintingResultSwaggerFile 1`] = `
 Object {
   "description": "Given API Spec DOES comply with company API rules.",
+  "highestSeverityLevel": "Warn",
   "isValidSpec": true,
   "linkApiRules": "https://onedirection.schwarz/architecture-best-practices/apis/",
   "lintingResults": Array [
     Object {
-      "code": "description-is-mandatory",
+      "code": "http-verbs-should-be-used",
+      "message": "HTTP verbs should be used to express different actions or functions on a resource; The HTTP verb /digital-twin/api/v1/products.put is missing.",
+      "path": Array [
+        "paths",
+        "/digital-twin/api/v1/products",
+      ],
+      "range": Object {
+        "end": Object {
+          "character": 1243,
+          "line": 0,
+        },
+        "start": Object {
+          "character": 60,
+          "line": 0,
+        },
+      },
+      "severity": 2,
+    },
+    Object {
+      "code": "path-description-is-mandatory",
       "message": "Every route of an API should have a description; property: /digital-twin/api/v1/products.description is missing",
       "path": Array [
         "paths",
@@ -26,57 +46,71 @@ Object {
       "severity": 1,
     },
     Object {
-      "code": "http-verbs-should-be-used",
-      "message": "HTTP verbs should be used to express different actions or functions on a resource; The HTTP verb /digital-twin/api/v1/products.put is missing.",
+      "code": "must-define-example-schema",
+      "message": "Every DTO must define at least one example; DTO is lacking an example #/paths/~1digital-twin~1api~1v1~1products/post/requestBody/content/application~1json",
       "path": Array [
         "paths",
         "/digital-twin/api/v1/products",
+        "post",
+        "requestBody",
+        "content",
+        "application/json",
       ],
       "range": Object {
         "end": Object {
-          "character": 1243,
+          "character": 296,
           "line": 0,
         },
         "start": Object {
-          "character": 60,
+          "character": 239,
           "line": 0,
         },
       },
       "severity": 1,
     },
     Object {
-      "code": "path-description",
-      "message": "Each path of an API must have a description; property \`description\` is missing for path #/paths/~1digital-twin~1api~1v1~1products",
+      "code": "must-define-example-schema",
+      "message": "Every DTO must define at least one example; DTO is lacking an example #/paths/~1digital-twin~1api~1v1~1products/post/responses/201/content/application~1json",
       "path": Array [
         "paths",
         "/digital-twin/api/v1/products",
+        "post",
+        "responses",
+        "201",
+        "content",
+        "application/json",
       ],
       "range": Object {
         "end": Object {
-          "character": 1243,
+          "character": 485,
           "line": 0,
         },
         "start": Object {
-          "character": 60,
+          "character": 427,
           "line": 0,
         },
       },
       "severity": 1,
     },
     Object {
-      "code": "description-is-mandatory",
-      "message": "Every route of an API should have a description; property: /digital-twin/api/v1/products/{ean}.description is missing",
+      "code": "must-define-example-schema",
+      "message": "Every DTO must define at least one example; DTO is lacking an example #/paths/~1digital-twin~1api~1v1~1products/get/responses/200/content/application~1json",
       "path": Array [
         "paths",
-        "/digital-twin/api/v1/products/{ean}",
+        "/digital-twin/api/v1/products",
+        "get",
+        "responses",
+        "200",
+        "content",
+        "application/json",
       ],
       "range": Object {
         "end": Object {
-          "character": 3155,
+          "character": 1028,
           "line": 0,
         },
         "start": Object {
-          "character": 1286,
+          "character": 946,
           "line": 0,
         },
       },
@@ -99,11 +133,11 @@ Object {
           "line": 0,
         },
       },
-      "severity": 1,
+      "severity": 2,
     },
     Object {
-      "code": "path-description",
-      "message": "Each path of an API must have a description; property \`description\` is missing for path #/paths/~1digital-twin~1api~1v1~1products~1{ean}",
+      "code": "path-description-is-mandatory",
+      "message": "Every route of an API should have a description; property: /digital-twin/api/v1/products/{ean}.description is missing",
       "path": Array [
         "paths",
         "/digital-twin/api/v1/products/{ean}",
@@ -115,6 +149,77 @@ Object {
         },
         "start": Object {
           "character": 1286,
+          "line": 0,
+        },
+      },
+      "severity": 1,
+    },
+    Object {
+      "code": "must-define-example-schema",
+      "message": "Every DTO must define at least one example; DTO is lacking an example #/paths/~1digital-twin~1api~1v1~1products~1{ean}/get/responses/200/content/application~1json",
+      "path": Array [
+        "paths",
+        "/digital-twin/api/v1/products/{ean}",
+        "get",
+        "responses",
+        "200",
+        "content",
+        "application/json",
+      ],
+      "range": Object {
+        "end": Object {
+          "character": 1635,
+          "line": 0,
+        },
+        "start": Object {
+          "character": 1577,
+          "line": 0,
+        },
+      },
+      "severity": 1,
+    },
+    Object {
+      "code": "must-define-example-schema",
+      "message": "Every DTO must define at least one example; DTO is lacking an example #/paths/~1digital-twin~1api~1v1~1products~1{ean}/put/requestBody/content/application~1json",
+      "path": Array [
+        "paths",
+        "/digital-twin/api/v1/products/{ean}",
+        "put",
+        "requestBody",
+        "content",
+        "application/json",
+      ],
+      "range": Object {
+        "end": Object {
+          "character": 2181,
+          "line": 0,
+        },
+        "start": Object {
+          "character": 2124,
+          "line": 0,
+        },
+      },
+      "severity": 1,
+    },
+    Object {
+      "code": "must-define-example-schema",
+      "message": "Every DTO must define at least one example; DTO is lacking an example #/paths/~1digital-twin~1api~1v1~1products~1{ean}/put/responses/200/content/application~1json",
+      "path": Array [
+        "paths",
+        "/digital-twin/api/v1/products/{ean}",
+        "put",
+        "responses",
+        "200",
+        "content",
+        "application/json",
+      ],
+      "range": Object {
+        "end": Object {
+          "character": 2366,
+          "line": 0,
+        },
+        "start": Object {
+          "character": 2308,
           "line": 0,
         },
       },


### PR DESCRIPTION
- Fixed the property 'highestSeverity' of the response of lintings. Now it's always present, even if the highest severity is just e.g. warn.
- Fixed the npm scripts for running tests so the service can be tested in e.g. watchmode
- Updated the commited and migrated rules
- Added the spectral-cli as a dev dependency and linked it to the pre-commit hook, so it does not have to be installed manually
