### PR TITLE
Removed auth

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -28,16 +28,8 @@
                     },
                     "400": {
                         "description": "\"apiType\" query param is missing."
-                    },
-                    "401": {
-                        "description": "API call was not authenticated"
                     }
                 },
-                "security": [
-                    {
-                        "basic": []
-                    }
-                ],
                 "tags": [
                     "rules"
                 ]
@@ -72,16 +64,8 @@
                     },
                     "400": {
                         "description": "Provided request body is missing mandatory properties."
-                    },
-                    "401": {
-                        "description": "API call was not authenticated."
                     }
                 },
-                "security": [
-                    {
-                        "basic": []
-                    }
-                ],
                 "tags": [
                     "lintings"
                 ]
@@ -129,12 +113,6 @@
         }
     ],
     "components": {
-        "securitySchemes": {
-            "basic": {
-                "type": "http",
-                "scheme": "basic"
-            }
-        },
         "schemas": {
             "CreateLintingDto": {
                 "type": "object",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "class-validator": "^0.13.2",
         "compression": "^1.7.4",
         "dotenv": "^10.0.0",
-        "express-basic-auth": "^1.2.0",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "rxjs": "^7.2.0",
@@ -3387,17 +3386,6 @@
         }
       ]
     },
-    "node_modules/basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -5114,14 +5102,6 @@
       },
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/express-basic-auth": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.2.1.tgz",
-      "integrity": "sha512-L6YQ1wQ/mNjVLAmK3AG1RK6VkokA1BIY6wmiH304Xtt/cLTps40EusZsU1Uop+v9lTDPxdtzbFmdXfFO3KEnwA==",
-      "dependencies": {
-        "basic-auth": "^2.0.1"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -13069,14 +13049,6 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
-    "basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -14412,14 +14384,6 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
-      }
-    },
-    "express-basic-auth": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/express-basic-auth/-/express-basic-auth-1.2.1.tgz",
-      "integrity": "sha512-L6YQ1wQ/mNjVLAmK3AG1RK6VkokA1BIY6wmiH304Xtt/cLTps40EusZsU1Uop+v9lTDPxdtzbFmdXfFO3KEnwA==",
-      "requires": {
-        "basic-auth": "^2.0.1"
       }
     },
     "external-editor": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "api-linting-service",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "api-linting-service",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@nestjs/common": "^8.2.4",
@@ -5362,9 +5362,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "funding": [
         {
           "type": "individual",
@@ -9955,9 +9955,9 @@
       }
     },
     "node_modules/urijs": {
-      "version": "1.19.7",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.7.tgz",
-      "integrity": "sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA=="
+      "version": "1.19.10",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.10.tgz",
+      "integrity": "sha512-EzauQlgKuJgsXOqoMrCiePBf4At5jVqRhXykF3Wfb8ZsOBMxPcfiVBcsHXug4Aepb/ICm2PIgqAUGMelgdrWEg=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -14568,9 +14568,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "6.5.0",
@@ -17956,9 +17956,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.7",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.7.tgz",
-      "integrity": "sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA=="
+      "version": "1.19.10",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.10.tgz",
+      "integrity": "sha512-EzauQlgKuJgsXOqoMrCiePBf4At5jVqRhXykF3Wfb8ZsOBMxPcfiVBcsHXug4Aepb/ICm2PIgqAUGMelgdrWEg=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-linting-service",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "API Linting as a http service",
   "author": "",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "class-validator": "^0.13.2",
     "compression": "^1.7.4",
     "dotenv": "^10.0.0",
-    "express-basic-auth": "^1.2.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",

--- a/src/health-probe/health-probe.controller.ts
+++ b/src/health-probe/health-probe.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, HttpStatus, Scope } from '@nestjs/common';
+import { Controller, Get, HttpStatus } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 
 @Controller('/.well-known/live')

--- a/src/lintings/lintings.controller.ts
+++ b/src/lintings/lintings.controller.ts
@@ -1,11 +1,9 @@
 import { BadRequestException, Body, Controller, Post } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
-  ApiBasicAuth,
   ApiCreatedResponse,
   ApiOperation,
   ApiTags,
-  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { LintingsService } from './lintings.service';
 import { CreateLintingDto } from './create-linting.dto';
@@ -26,11 +24,7 @@ export class LintingsController {
   @ApiBadRequestResponse({
     description: 'Provided request body is missing mandatory properties.',
   })
-  @ApiUnauthorizedResponse({
-    description: 'API call was not authenticated.',
-  })
   @ApiTags('lintings')
-  @ApiBasicAuth()
   @Post()
   createLinting(
     @Body() createLintingDto: CreateLintingDto,

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,7 +55,6 @@ async function bootstrap() {
         .setVersion(apiVersion)
         .addServer(openApiServerNameLocal)
         .addServer(openApiServerNameProd)
-        .addBasicAuth()
         .setContact(contactName, contactLink, contactEmail)
         .addTag(apiTag)
         .setDescription(apiDescription)

--- a/src/rules/rules.controller.ts
+++ b/src/rules/rules.controller.ts
@@ -8,12 +8,10 @@ import {
 } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
-  ApiBasicAuth,
   ApiOkResponse,
   ApiOperation,
   ApiQuery,
   ApiTags,
-  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { createReadStream, ReadStream } from 'fs';
 import { join } from 'path';
@@ -31,14 +29,10 @@ export class RulesController {
   @ApiOkResponse({
     description: 'Provides company API linting rules as stream download.',
   })
-  @ApiUnauthorizedResponse({
-    description: 'API call was not authenticated',
-  })
   @ApiBadRequestResponse({
     description: '"apiType" query param is missing.',
   })
   @ApiTags('rules')
-  @ApiBasicAuth()
   @ApiQuery({
     name: 'apiType',
     enum: Object.keys(ApiType),


### PR DESCRIPTION
Basic auth was removed from the openapi spec. It's prefered to handle authentication for the service using an other service in front of it, like a reverse proxy or api gateway.